### PR TITLE
DEVOPS-449: IPTABLES POSTROUTING to Anchor IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Default: `{{ do.droplet.id }}`
 #### [`digital_ocean_floating_ip`][digital_ocean_floating_ip]
 Default: `none`
 This is a mandatory variable and is supposed to be set in the host_vars file for the specific host you want to assign the Floating IP to (because a Floating IP can be associated to only one host at time), in this way you can associate multiple Floating IP to distinct Droplets.
+
+#### [`digital_ocean_static_id`][digital_ocean_static_id]
+Default: `{{ ansible_ssh_host | mandatory }}`
+This paramater is necessary and mandatory to be able to set up the proper IPTABLES postrouting statments to SMTP traffic
+
+#### [`digital_ocean_smtp_ports`][digital_ocean_smtp_ports]
+Default: `["25","465","587","2525","2526"]`
+This paramater is necessary and mandatory to be able to set up the proper IPTABLES postrouting statments to SMTP traffic
+
 ## Example Playbook
 ----------------
 
@@ -52,4 +61,6 @@ Author Marco Massari Calderone at Inviqa UK Ltd
 [digital_ocean_api_token]: https://github.com/inviqa/ansible-digitalocean-floating-ip/blob/master/defaults/main.yml#L3 "Link to variable on master"
 [digital_ocean_droplet_id]: https://github.com/inviqa/ansible-digitalocean-floating-ip/blob/master/defaults/main.yml#L4 "Link to variable on master"
 [digital_ocean_floating_ip]: https://github.com/inviqa/ansible-digitalocean-floating-ip/blob/master/defaults/main.yml#L5 "Link to variable on master"
+[digital_ocean_static_id]: https://github.com/inviqa/ansible-digitalocean-floating-ip/blob/master/defaults/main.yml#L6 "Link to variable on master"
+[digital_ocean_smtp_ports]: https://github.com/inviqa/ansible-digitalocean-floating-ip/blob/master/defaults/main.yml#L7 "Link to variable on master"
 [licence]: https://raw.githubusercontent.com/inviqa/ansible-digitalocean-floating-ip/master/LICENSE

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 digital_ocean_api_base_url:       "https://api.digitalocean.com/v2/"
+digital_ocean_metadata_url:       "http://169.254.169.254/metadata/v1/interfaces/public/0/anchor_ipv4/address"
 digital_ocean_api_token:          "{{ enc_do_v2_api_key }}"
 digital_ocean_droplet_id:         "{{ do.droplet.id | mandatory }}"
 digital_ocean_floating_ip:        "{{ mandatory }}"
+digital_ocean_static_id:          "{{ ansible_ssh_host | mandatory }}"
+digital_ocean_smtp_ports:         ["25","465","587","2525","2526"]
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
     floating_ip_is_assigned: "{{ not (do_floating_ip_json_response.content|from_json).floating_ip.droplet is none}}"
     droplet_id_associated_to_floating_ip: ""
     floating_ip_is_assigned_to_this_droplet: false
+    can_retrive_anchor_ip_associated_to_this_droplet: false
 
 - set_fact:
     droplet_id_associated_to_floating_ip : "{{(do_floating_ip_json_response.content|from_json).floating_ip.droplet.id }}"
@@ -76,3 +77,56 @@
   delegate_to: localhost
   register: do_floating_ip_assign_action_json_response
   when:  not floating_ip_is_assigned_to_this_droplet
+
+- set_fact:
+    floating_ip_is_assigned_to_this_droplet: true
+  when: droplet_id_associated_to_floating_ip == digital_ocean_droplet_id
+
+- name:       Retrive DO Droplet Anchor IP
+  uri:
+    url: "{{digital_ocean_metadata_url}}"
+    body_format:  raw
+    method: GET
+    follow_redirects: all
+    return_content: yes
+    timeout: 3
+  register:   do_droplet_anchor_ip
+  when:   floating_ip_is_assigned_to_this_droplet
+  retries: 3
+  ignore_errors: true
+
+- set_fact:
+    can_retrive_anchor_ip_associated_to_this_droplet: true
+    anchor_ip_associated_to_droplet : "{{do_droplet_anchor_ip.content}}"
+  when: not (do_droplet_anchor_ip.content == "" or do_droplet_anchor_ip.content == "not found")
+
+- debug:
+    msg:
+      - "It wasn't possible to retrive the Anchor IP for this Droplet."
+      - "Most probably the Outgoing Traffic is already forwarded to the Floating IP."
+      - "IPTABLES outgoing traffic routing won't be modified"
+      - "(SMTP outgoing traffic routing will still be updated)."
+  when: not can_retrive_anchor_ip_associated_to_this_droplet
+
+- name:       Make sure that SMTP traffic is coming from the DO Droplet Static IP
+  iptables:
+    table: nat
+    chain: POSTROUTING
+    destination_port: "{{item}}"
+    to_source: "{{ansible_ssh_host}}"
+    protocol: tcp
+    jump: SNAT
+    comment: Make sure that SMTP traffic is coming from the DO Droplet Static IP
+  become: yes
+  with_items: "{{digital_ocean_smtp_ports}}"
+
+- name:       Redirect all outgoing traffic to the Floating IP
+  iptables:
+    table: nat
+    chain: POSTROUTING
+    to_source: "{{anchor_ip_associated_to_droplet}}"
+    protocol: tcp
+    jump: SNAT
+    comment: Redirect all outgoing traffic to the Floating IP
+  become: yes
+  when: can_retrive_anchor_ip_associated_to_this_droplet


### PR DESCRIPTION
The OUTGOING traffic is of the Droplet will now be showing originating from the Floating IP
thanks to the implementation of 
- IPTABLES POSTROUTING to Anchor IP 

Because DO by policy is currently blocking SMTP traffic to show from a Floating IP additional postrouting rules have been added to the IPTABLES to forse the SMTP traffic of a few default ports to be routed via the Static IP of the Droplet